### PR TITLE
Add custom code injection and Encoder protocol

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,14 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
-          - { target: aarch64-apple-darwin, os: macos-latest }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
-          - {
-              target: aarch64-unknown-linux-gnu,
-              os: ubuntu-latest,
-              use-cross: true,
-            }
+          # macOS
+          - { target: aarch64-apple-darwin, os: macos-14 }
+          # Linux glibc
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          # Linux musl (Alpine)
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true, rustflags: "-C target-feature=-crt-static" }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true, rustflags: "-C target-feature=-crt-static" }
 
     steps:
       - name: Checkout source code
@@ -38,6 +39,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.job.target }}
+
+      - name: Set RUSTFLAGS for musl targets
+        if: ${{ matrix.job.rustflags }}
+        shell: bash
+        run: echo "RUSTFLAGS=${{ matrix.job.rustflags }}" >> $GITHUB_ENV
 
       - name: Build the project
         id: build-crate

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.1
-elixir 1.18.3-otp-27
+erlang 27.3.4.2
+elixir 1.18.4-otp-27

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Add baml_elixir to your mix.exs:
 ```elixir
 def deps do
   [
-    {:baml_elixir, "~> 1.0.0-pre.23"}
+    {:baml_elixir, "~> 1.0.0-pre.24"}
   ]
 end
 ```
@@ -246,8 +246,10 @@ end
 This also downloads the pre built NIFs for these targets:
 
 - aarch64-apple-darwin (Apple Silicon)
-- x86_64-unknown-linux-gnu
-- aarch64-unknown-linux-gnu
+- x86_64-unknown-linux-gnu (Linux x86_64)
+- aarch64-unknown-linux-gnu (Linux ARM64)
+- x86_64-unknown-linux-musl (Alpine Linux x86_64)
+- aarch64-unknown-linux-musl (Alpine Linux ARM64)
 
 If you need to build the NIFs for other targets, you need to clone the repo and build it locally as documented below.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Call BAML functions from Elixir, using a Rust NIF.
 
+> **Note:** This package (`bamlixir`) is a fork of
+> [`baml_elixir`](https://github.com/emilsoman/baml_elixir) by
+> [Emil Soman](https://github.com/emilsoman), published under the
+> Apache-2.0 license. It is republished on Hex under a new name to
+> allow for faster iteration and release cycles. Changes made in this
+> fork are regularly fed back to the upstream repository.
+
 ## First of all, can this be used in production?
 
 Well, I use it in production. But it's way too early for you if you expect stable APIs
@@ -233,12 +240,12 @@ class DynamicEmployee {
 
 ## Installation
 
-Add baml_elixir to your mix.exs:
+Add `bamlixir` to your mix.exs:
 
 ```elixir
 def deps do
   [
-    {:baml_elixir, "~> 1.0.0-pre.24"}
+    {:bamlixir, "~> 1.1.0-baml0.219.0"}
   ]
 end
 ```

--- a/checksum-Elixir.BamlElixir.Native.exs
+++ b/checksum-Elixir.BamlElixir.Native.exs
@@ -1,5 +1,5 @@
 %{
-  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:199bae2854507fc8208b4973c359a8d8088c1a5801bfd66640df8bd6cfe7b569",
-  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:f41577bb9b4441409a5bc0b36ff353ffe1c939ce2b0adaf53c3c59c7bf358a25",
-  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:7318f97349f1bc18fb9714c1231d5e8530e80f904e3d4dd4b75f4a47c8a4c5c8",
+  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:f1ac19ff5ceb7e7959117e4a30aa4d1f2684031501603db4e3cd4e2162e990b9",
+  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:d07ba5af4725e1c3f5d5e08eb74a438692d11e3234cefc12186ec1fa53f75576",
+  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:231bcb69251fc37dbef251ba8ce1952737fd45a017b6f5c17399bd315210a4c3",
 }

--- a/checksum-Elixir.BamlElixir.Native.exs
+++ b/checksum-Elixir.BamlElixir.Native.exs
@@ -1,4 +1,5 @@
 %{
-  "libbaml_elixir-v1.0.0-pre.22-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:8f378fce2e43b9e4217acd1520506f76ad5b1455f2bf6ae455abeaa0f9fad20d",
-  "libbaml_elixir-v1.0.0-pre.22-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:a7a38b869b41a8eee50ea93828ef62f1fab38ba9fba7f765dbaa8e84a8ff6653",
+  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:199bae2854507fc8208b4973c359a8d8088c1a5801bfd66640df8bd6cfe7b569",
+  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:f41577bb9b4441409a5bc0b36ff353ffe1c939ce2b0adaf53c3c59c7bf358a25",
+  "libbaml_elixir-v1.0.0-pre.23-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:7318f97349f1bc18fb9714c1231d5e8530e80f904e3d4dd4b75f4a47c8a4c5c8",
 }

--- a/checksum-Elixir.BamlElixir.Native.exs
+++ b/checksum-Elixir.BamlElixir.Native.exs
@@ -1,5 +1,5 @@
 %{
-  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:f1ac19ff5ceb7e7959117e4a30aa4d1f2684031501603db4e3cd4e2162e990b9",
-  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:d07ba5af4725e1c3f5d5e08eb74a438692d11e3234cefc12186ec1fa53f75576",
-  "libbaml_elixir-v1.0.0-baml0.219.0-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:231bcb69251fc37dbef251ba8ce1952737fd45a017b6f5c17399bd315210a4c3",
+  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:5f3c4aa74ce9b28e7d2bc3820c31540b29b8b69b516018f12205c9d686d45a3f",
+  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:0fa88fa70cf5489a0dd30bab668b3e2ae44e42bcaef565aad28ee2c1ff98e47a",
+  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:1f44ac11b453306c1a820f66c14fedfd85ff30f1b5b691df04e0ac917603628e",
 }

--- a/checksum-Elixir.BamlElixir.Native.exs
+++ b/checksum-Elixir.BamlElixir.Native.exs
@@ -1,5 +1,7 @@
 %{
-  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:5f3c4aa74ce9b28e7d2bc3820c31540b29b8b69b516018f12205c9d686d45a3f",
-  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:0fa88fa70cf5489a0dd30bab668b3e2ae44e42bcaef565aad28ee2c1ff98e47a",
-  "libbaml_elixir-v1.0.1-baml0.219.0-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:1f44ac11b453306c1a820f66c14fedfd85ff30f1b5b691df04e0ac917603628e",
+  "libbaml_elixir-v1.1.0-baml0.219.0-nif-2.15-aarch64-apple-darwin.so.tar.gz" => "sha256:f1d54d350087a3e19c6482189dcd6909976c26c26c22ee68ddcf61879467a4a2",
+  "libbaml_elixir-v1.1.0-baml0.219.0-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz" => "sha256:37945b0d71349ebac33676c16994c71394ced42f20d530ee379d14d27c02ce00",
+  "libbaml_elixir-v1.1.0-baml0.219.0-nif-2.15-aarch64-unknown-linux-musl.so.tar.gz" => "sha256:b6b6784019eef327aefe3bbc90d6f05fec53dfaf7dc424492d9ffc0d01c6c623",
+  "libbaml_elixir-v1.1.0-baml0.219.0-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz" => "sha256:c8ece3cdd3080a862fd1aaf88e7fabeb4a3eb35cbf7333747ee094d938da37ae",
+  "libbaml_elixir-v1.1.0-baml0.219.0-nif-2.15-x86_64-unknown-linux-musl.so.tar.gz" => "sha256:850c2d5a0e01ac0fbe625e8f4d7c7a817706fcbe59acea9ebd71ed8adb35dd5b",
 }

--- a/lib/baml_elixir.ex
+++ b/lib/baml_elixir.ex
@@ -1,5 +1,5 @@
 defmodule BamlElixir do
-  @baml_version "0.208.3"
+  @baml_version "0.219.0"
 
   def baml_version, do: @baml_version
 end

--- a/lib/baml_elixir/client.ex
+++ b/lib/baml_elixir/client.ex
@@ -35,7 +35,8 @@ defmodule BamlElixir.Client do
     baml_enum_types = baml_types[:enums]
     baml_functions = baml_types[:functions]
 
-    baml_class_types_quoted = generate_class_types(baml_class_types, __CALLER__)
+    class_body = Keyword.get(opts, :inject_code, nil)
+    baml_class_types_quoted = generate_class_types(baml_class_types, __CALLER__, class_body)
     baml_enum_types_quoted = generate_enum_types(baml_enum_types, __CALLER__)
     baml_functions_quoted = generate_function_modules(baml_functions, path, __CALLER__)
     recompile_function = generate_recompile_function(baml_src_path, baml_files)
@@ -239,7 +240,7 @@ defmodule BamlElixir.Client do
 
   # Every class in the BAML source file is converted to an Elixir module
   # with a `defstruct/1` and a `@type t/0` type.
-  defp generate_class_types(class_types, caller) do
+  defp generate_class_types(class_types, caller, class_body) do
     module = caller.module
 
     for {type_name, %{"fields" => fields, "dynamic" => dynamic}} <- class_types do
@@ -249,6 +250,7 @@ defmodule BamlElixir.Client do
 
       quote do
         defmodule unquote(module_name) do
+          unquote(class_body)
           defstruct unquote(field_names)
           @type t :: %__MODULE__{unquote_splicing(field_types)}
 
@@ -492,9 +494,10 @@ defmodule BamlElixir.Client do
   end
 
   defp to_map(args) when is_struct(args) do
-    args
-    |> Map.from_struct()
-    |> to_map()
+    case BamlElixir.Encoder.encode(args) do
+      ^args -> args |> Map.from_struct() |> to_map()
+      encoded -> to_map(encoded)
+    end
   end
 
   defp to_map(args) when is_map(args) do
@@ -503,6 +506,14 @@ defmodule BamlElixir.Client do
 
   defp to_map(args) when is_list(args) do
     Enum.map(args, &to_map/1)
+  end
+
+  defp to_map(args) when is_tuple(args) do
+    args |> Tuple.to_list() |> to_map()
+  end
+
+  defp to_map(args) when is_atom(args) and args not in [true, false, nil] do
+    Atom.to_string(args)
   end
 
   defp to_map(args) do

--- a/lib/baml_elixir/encoder.ex
+++ b/lib/baml_elixir/encoder.ex
@@ -1,0 +1,12 @@
+defprotocol BamlElixir.Encoder do
+  @fallback_to_any true
+  def encode(value)
+end
+
+defimpl BamlElixir.Encoder, for: [Date, Time, DateTime, NaiveDateTime] do
+  def encode(value), do: to_string(value)
+end
+
+defimpl BamlElixir.Encoder, for: Any do
+  def encode(value), do: value
+end

--- a/lib/baml_elixir/native.ex
+++ b/lib/baml_elixir/native.ex
@@ -8,9 +8,14 @@ defmodule BamlElixir.Native do
     force_build: System.get_env("BAML_ELIXIR_BUILD") in ["1", "true"],
     version: version,
     targets: [
+      # macOS
       "aarch64-apple-darwin",
+      # Linux glibc
       "x86_64-unknown-linux-gnu",
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      # Linux musl (Alpine)
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl"
     ]
 
   def call(_function_name, _args, _path, _collectors, _client_registry, _tb),

--- a/lib/baml_elixir/native.ex
+++ b/lib/baml_elixir/native.ex
@@ -2,7 +2,7 @@ defmodule BamlElixir.Native do
   version = Mix.Project.config()[:version]
 
   use RustlerPrecompiled,
-    otp_app: :baml_elixir,
+    otp_app: :bamlixir,
     base_url: "https://github.com/bagrat/baml_elixir/releases/download/v#{version}/",
     force_build: System.get_env("BAML_ELIXIR_BUILD") in ["1", "true"],
     version: version,

--- a/lib/baml_elixir/native.ex
+++ b/lib/baml_elixir/native.ex
@@ -3,6 +3,7 @@ defmodule BamlElixir.Native do
 
   use RustlerPrecompiled,
     otp_app: :bamlixir,
+    crate: :baml_elixir,
     base_url: "https://github.com/bagrat/baml_elixir/releases/download/v#{version}/",
     force_build: System.get_env("BAML_ELIXIR_BUILD") in ["1", "true"],
     version: version,

--- a/lib/baml_elixir/native.ex
+++ b/lib/baml_elixir/native.ex
@@ -3,7 +3,7 @@ defmodule BamlElixir.Native do
 
   use RustlerPrecompiled,
     otp_app: :baml_elixir,
-    base_url: "https://github.com/emilsoman/baml_elixir/releases/download/v#{version}/",
+    base_url: "https://github.com/bagrat/baml_elixir/releases/download/v#{version}/",
     force_build: System.get_env("BAML_ELIXIR_BUILD") in ["1", "true"],
     version: version,
     targets: [

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule BamlElixir.MixProject do
       ],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/bagrat/baml_elixir"},
-      maintainers: ["bagrat"]
+      maintainers: ["Emil Soman", "bagrat"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BamlElixir.MixProject do
   use Mix.Project
 
-  @version "1.0.0-pre.23"
+  @version "1.0.0-baml0.219.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,11 @@
 defmodule BamlElixir.MixProject do
   use Mix.Project
 
-  @version "1.0.0-baml0.219.0"
+  @version "1.0.1-baml0.219.0"
 
   def project do
     [
-      app: :baml_elixir,
+      app: :bamlixir,
       description: "Call BAML functions from Elixir.",
       version: @version,
       elixir: "~> 1.17",

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule BamlElixir.MixProject do
 
   defp package do
     [
+      name: "bamlixir",
       files: [
         "lib",
         "checksum-*.exs",
@@ -45,8 +46,8 @@ defmodule BamlElixir.MixProject do
         "LICENSE"
       ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/emilsoman/baml_elixir"},
-      maintainers: ["Emil Soman"]
+      links: %{"GitHub" => "https://github.com/bagrat/baml_elixir"},
+      maintainers: ["bagrat"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BamlElixir.MixProject do
   use Mix.Project
 
-  @version "1.0.1-baml0.219.0"
+  @version "1.1.0-baml0.219.0"
 
   def project do
     [

--- a/native/baml_elixir/Cargo.lock
+++ b/native/baml_elixir/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +105,12 @@ name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -339,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.2"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -351,23 +348,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http 0.62.0",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.4",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -376,16 +374,17 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.76.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b538f72f5ab8d23de44aacd109788c37e268fe9f4d060168714a12514d73b434"
+checksum = "65d69fe4cf7e0f812c12ad76b5a50ad7c5e030a424a02896c60af229ea8a2c38"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.61.1",
- "aws-smithy-json 0.61.3",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -393,7 +392,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "once_cell",
+ "hyper 0.14.32",
  "regex-lite",
  "tracing",
 ]
@@ -407,8 +406,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.0",
- "aws-smithy-json 0.61.3",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -430,8 +429,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.0",
- "aws-smithy-json 0.61.3",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -453,8 +452,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.0",
- "aws-smithy-json 0.61.3",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -470,12 +469,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.62.0",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.4",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -484,7 +484,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "percent-encoding",
  "sha2",
  "time",
@@ -493,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -504,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.8"
+version = "0.60.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
+checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -535,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.61.1"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f276f21c7921fe902826618d1423ae5bf74cf8c1b8472aee8434f3dfd31824"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -545,9 +544,10 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
+ "futures-util",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -556,19 +556,19 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.0"
+version = "0.63.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.12",
+ "futures-util",
  "http 1.3.1",
- "http-body 0.4.6",
- "once_cell",
+ "http-body 1.0.1",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -577,20 +577,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.1"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.8",
+ "h2 0.3.26",
+ "h2 0.4.13",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs",
  "tokio",
  "tracing",
 ]
@@ -606,21 +608,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445d065e76bc1ef54963db400319f1dd3ebb3e0a74af20f7f7630625b0cc7cc0"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
 dependencies = [
  "aws-smithy-runtime-api",
- "once_cell",
 ]
 
 [[package]]
@@ -635,12 +636,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.62.0",
+ "aws-smithy-http 0.63.4",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -651,7 +652,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "once_cell",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -660,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.4"
+version = "1.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -677,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
+checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -709,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -803,37 +804,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "baml-compiler"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-types",
+ "baml-viz-events",
  "baml-vm",
  "internal-baml-ast",
  "internal-baml-diagnostics",
  "internal-baml-parser-database",
  "itertools 0.14.0",
+ "log",
  "pretty",
+ "reqwest",
+ "serde_json",
 ]
 
 [[package]]
 name = "baml-derive"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "baml-log"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -907,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "baml-runtime"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -928,8 +918,10 @@ dependencies = [
  "baml-log",
  "baml-rpc",
  "baml-types",
+ "baml-viz-events",
  "baml-vm",
  "base64 0.22.1",
+ "blake3",
  "bytes",
  "cfg-if",
  "chrono",
@@ -949,6 +941,7 @@ dependencies = [
  "envy",
  "eventsource-stream",
  "fastrand",
+ "flate2",
  "futures",
  "futures-timer",
  "gcp_auth",
@@ -979,6 +972,7 @@ dependencies = [
  "minijinja",
  "notify-debouncer-full",
  "once_cell",
+ "percent-encoding",
  "pin-project-lite",
  "pretty",
  "pretty_assertions",
@@ -996,6 +990,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shell-escape",
+ "similar",
  "static_assertions",
  "stream-cancel",
  "strsim",
@@ -1027,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "baml-types"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-ids",
@@ -1052,11 +1047,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "baml-vm"
-version = "0.208.3"
+name = "baml-viz-events"
+version = "0.219.0"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "baml-vm"
+version = "0.219.0"
+dependencies = [
+ "anyhow",
  "baml-types",
+ "baml-viz-events",
  "colored",
+ "indexmap 2.9.0",
  "internal-baml-diagnostics",
  "tokio",
 ]
@@ -1118,6 +1123,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "bstd"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1258,7 +1277,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -1408,6 +1427,12 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "constptr"
@@ -1733,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "dir-writer"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-log",
@@ -1969,6 +1994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2177,7 @@ dependencies = [
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2154,18 +2189,19 @@ dependencies = [
 
 [[package]]
 name = "generators-go"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
  "baml-types",
  "dir-writer",
  "internal-baml-core",
+ "type_test_spec",
 ]
 
 [[package]]
 name = "generators-lib"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-log",
@@ -2174,6 +2210,7 @@ dependencies = [
  "generators-openapi",
  "generators-python",
  "generators-ruby",
+ "generators-rust",
  "generators-typescript",
  "indexmap 2.9.0",
  "internal-baml-core",
@@ -2183,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "generators-openapi"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -2199,18 +2236,20 @@ dependencies = [
 
 [[package]]
 name = "generators-python"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
+ "baml-compiler",
  "baml-types",
  "dir-writer",
  "internal-baml-core",
+ "type_test_spec",
 ]
 
 [[package]]
 name = "generators-ruby"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -2220,16 +2259,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "generators-typescript"
-version = "0.208.3"
+name = "generators-rust"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
+ "baml-types",
+ "dir-writer",
+ "internal-baml-core",
+ "type_test_spec",
+]
+
+[[package]]
+name = "generators-typescript"
+version = "0.219.0"
+dependencies = [
+ "anyhow",
+ "askama",
+ "baml-compiler",
  "baml-types",
  "dir-writer",
  "indexmap 2.9.0",
  "internal-baml-core",
  "regex",
+ "type_test_spec",
 ]
 
 [[package]]
@@ -2266,12 +2319,6 @@ dependencies = [
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
@@ -2318,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2536,7 +2583,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2552,7 +2599,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.13",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -2575,7 +2622,6 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2591,7 +2637,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.26",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -2628,7 +2674,7 @@ dependencies = [
  "hyper 1.6.0",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2913,12 +2959,13 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-ast"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-types",
  "bstd",
  "either",
+ "indexmap 2.9.0",
  "internal-baml-diagnostics",
  "log",
  "pest",
@@ -2932,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-core"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-compiler",
@@ -2954,6 +3001,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "minijinja",
+ "minijinja-contrib",
  "once_cell",
  "rayon",
  "regex",
@@ -2969,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -2982,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-jinja"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -2996,13 +3044,15 @@ dependencies = [
  "minijinja",
  "serde",
  "serde_json",
+ "serde_yaml",
  "strsim",
  "strum",
+ "toon",
 ]
 
 [[package]]
 name = "internal-baml-jinja-types"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -3020,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-derive",
@@ -3046,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "internal-baml-ast",
  "internal-baml-diagnostics",
@@ -3058,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "internal-llm-client"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3151,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -3181,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3197,7 +3247,7 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonish"
-version = "0.208.3"
+version = "0.219.0"
 dependencies = [
  "anyhow",
  "baml-types",
@@ -3286,9 +3336,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"
@@ -3411,8 +3461,8 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.11.0"
-source = "git+https://github.com/boundaryml/minijinja.git?branch=main#ee25c021c8bb78d7ca11fa99972918eea4585330"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
 dependencies = [
  "aho-corasick",
  "indexmap 2.9.0",
@@ -3420,6 +3470,15 @@ dependencies = [
  "serde_json",
  "unicase",
  "unicode-ident",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.16.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=value-cmp#8cfc770a5dffeda2de5b910d2b9f870d7edeff7c"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]
@@ -3435,6 +3494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3647,15 +3707,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -4258,7 +4309,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.13",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4274,7 +4325,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4322,12 +4373,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -4429,18 +4474,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -4449,15 +4482,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -4504,9 +4528,9 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4635,10 +4659,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -4654,10 +4679,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4837,6 +4871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,6 +4923,16 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5202,27 +5258,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio 1.0.3",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5281,6 +5336,16 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toon"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa605a2aa68fefdedc9560bd765ce3ad89d45ac1d3ebad43724621098c9299a"
+dependencies = [
+ "regex",
+ "serde_json",
 ]
 
 [[package]]
@@ -5440,6 +5505,10 @@ dependencies = [
  "thiserror 2.0.12",
  "uuid",
 ]
+
+[[package]]
+name = "type_test_spec"
+version = "0.1.0"
 
 [[package]]
 name = "typed-arena"
@@ -5689,28 +5758,14 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -5728,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5738,22 +5793,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
@@ -5787,9 +5842,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5867,7 +5922,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
 ]
@@ -5901,6 +5956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5926,7 +5987,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -5945,7 +6006,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -5976,6 +6037,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5999,11 +6078,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6019,6 +6115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6029,6 +6131,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6043,10 +6151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6061,6 +6181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6071,6 +6197,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6085,6 +6217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6095,6 +6233,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/native/baml_elixir/src/collector.rs
+++ b/native/baml_elixir/src/collector.rs
@@ -65,6 +65,8 @@ impl Encoder for Usage {
             .unwrap()
             .map_put("output_tokens", self.inner.output_tokens)
             .unwrap()
+            .map_put("cached_input_tokens", self.inner.cached_input_tokens)
+            .unwrap()
     }
 }
 

--- a/native/baml_elixir/src/lib.rs
+++ b/native/baml_elixir/src/lib.rs
@@ -389,6 +389,7 @@ fn call<'a>(
         client_registry.as_ref(), // client registry (optional)
         collectors,
         std::env::vars().collect(),
+        None,                // tags
         TripWire::new(None), // TODO: Add tripwire
     );
 
@@ -440,6 +441,7 @@ fn stream<'a>(
         collectors,
         std::env::vars().collect(),
         TripWire::new(None), // TODO: Add tripwire
+        None,                // tags
     );
 
     match result {
@@ -500,7 +502,7 @@ fn parse_baml(env: Env, path: Option<String>) -> NifResult<Term> {
         Err(e) => return Err(Error::Term(Box::new(e.to_string()))),
     };
 
-    let ir = runtime.inner.ir.clone();
+    let ir = runtime.ir.clone();
 
     // Create a map of the classes and their fields along with their types
     let mut class_fields = HashMap::new();

--- a/test/baml_elixir_test.exs
+++ b/test/baml_elixir_test.exs
@@ -109,6 +109,74 @@ defmodule BamlElixirTest do
              BamlElixirTest.WhichModelUnion.call(%{}, %{client_registry: client_registry})
   end
 
+  @tag :collector
+  test "collector usage includes cached_input_tokens from fake server" do
+    BamlElixirTest.FakeOpenAIServer.expect_chat_completion("GPT", %{}, %{cached_tokens: 42})
+    base_url = BamlElixirTest.FakeOpenAIServer.start_base_url()
+
+    client_registry = %{
+      primary: "InjectedClient",
+      clients: [
+        %{
+          name: "InjectedClient",
+          provider: "openai-generic",
+          retry_policy: nil,
+          options: %{
+            base_url: base_url,
+            api_key: "test-key",
+            model: "gpt-4o-mini"
+          }
+        }
+      ]
+    }
+
+    collector = BamlElixir.Collector.new("test-collector")
+
+    assert {:ok, "GPT"} =
+             BamlElixirTest.WhichModelUnion.call(%{}, %{
+               client_registry: client_registry,
+               collectors: [collector]
+             })
+
+    usage = BamlElixir.Collector.usage(collector)
+    assert usage["input_tokens"] == 1
+    assert usage["output_tokens"] == 1
+    assert usage["cached_input_tokens"] == 42
+  end
+
+  @tag :collector
+  test "collector usage returns zero cached_input_tokens when none cached" do
+    BamlElixirTest.FakeOpenAIServer.expect_chat_completion("GPT")
+    base_url = BamlElixirTest.FakeOpenAIServer.start_base_url()
+
+    client_registry = %{
+      primary: "InjectedClient",
+      clients: [
+        %{
+          name: "InjectedClient",
+          provider: "openai-generic",
+          retry_policy: nil,
+          options: %{
+            base_url: base_url,
+            api_key: "test-key",
+            model: "gpt-4o-mini"
+          }
+        }
+      ]
+    }
+
+    collector = BamlElixir.Collector.new("test-collector")
+
+    assert {:ok, "GPT"} =
+             BamlElixirTest.WhichModelUnion.call(%{}, %{
+               client_registry: client_registry,
+               collectors: [collector]
+             })
+
+    usage = BamlElixir.Collector.usage(collector)
+    assert usage["cached_input_tokens"] == 0
+  end
+
   test "parses into a struct" do
     assert {:ok, %BamlElixirTest.Person{name: "John Doe", age: 28}} =
              BamlElixirTest.ExtractPerson.call(%{info: "John Doe, 28, Engineer"})

--- a/test/custom_code_injection_test.exs
+++ b/test/custom_code_injection_test.exs
@@ -1,0 +1,31 @@
+defmodule CustomCodeClient do
+  use BamlElixir.Client,
+    path: "test/baml_src",
+    inject_code: (
+      def custom_greeting, do: "Hello from #{__MODULE__}"
+    )
+end
+
+defmodule CustomCodeInjectionTest do
+  use ExUnit.Case
+
+  @tag :custom_code
+  test "custom function defined in do block is callable on generated class modules" do
+    assert CustomCodeClient.Person.custom_greeting() =~ "CustomCodeClient.Person"
+  end
+
+  @tag :custom_code
+  test "__MODULE__ in the block resolves to the generated class module name" do
+    assert CustomCodeClient.Person.custom_greeting() == "Hello from Elixir.CustomCodeClient.Person"
+    assert CustomCodeClient.Attendees.custom_greeting() == "Hello from Elixir.CustomCodeClient.Attendees"
+  end
+
+  @tag :custom_code
+  test "existing behavior (no do block) still works" do
+    # TypeCoercionClient (defined in type_coercion_test.exs) uses no do block
+    # and should still compile. We also verify struct creation works.
+    person = TypeCoercionClient.Person.__struct__()
+    assert person.name == nil
+    assert person.age == nil
+  end
+end

--- a/test/support/fake_openai_server.ex
+++ b/test/support/fake_openai_server.ex
@@ -18,6 +18,14 @@ defmodule BamlElixirTest.FakeOpenAIServer do
   @spec expect_chat_completion(String.t(), expected_headers()) :: :ok
   def expect_chat_completion(response_content, expected_headers \\ %{})
       when is_binary(response_content) and is_map(expected_headers) do
+    expect_chat_completion(response_content, expected_headers, %{})
+  end
+
+  @spec expect_chat_completion(String.t(), expected_headers(), map()) :: :ok
+  def expect_chat_completion(response_content, expected_headers, opts)
+      when is_binary(response_content) and is_map(expected_headers) and is_map(opts) do
+    cached_tokens = Map.get(opts, :cached_tokens, 0)
+
     body =
       Jason.encode!(%{
         "id" => "chatcmpl-test",
@@ -31,7 +39,12 @@ defmodule BamlElixirTest.FakeOpenAIServer do
             "finish_reason" => "stop"
           }
         ],
-        "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
+        "usage" => %{
+          "prompt_tokens" => 1,
+          "completion_tokens" => 1,
+          "total_tokens" => 2,
+          "prompt_tokens_details" => %{"cached_tokens" => cached_tokens, "audio_tokens" => 0}
+        }
       })
 
     normalized_expected_headers =

--- a/test/type_coercion_test.exs
+++ b/test/type_coercion_test.exs
@@ -1,0 +1,91 @@
+defmodule TypeCoercionClient do
+  use BamlElixir.Client, path: "test/baml_src"
+end
+
+defmodule TypeCoercionTest do
+  use ExUnit.Case
+
+  import Mox
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  defp call_extract_person(args) do
+    BamlElixirTest.FakeOpenAIServer.expect_chat_completion(
+      ~s|{"name": "Test", "age": 1}|
+    )
+
+    base_url = BamlElixirTest.FakeOpenAIServer.start_base_url()
+
+    client_registry = %{
+      primary: "InjectedClient",
+      clients: [
+        %{
+          name: "InjectedClient",
+          provider: "openai-generic",
+          retry_policy: nil,
+          options: %{
+            base_url: base_url,
+            api_key: "test-key",
+            model: "gpt-4o-mini"
+          }
+        }
+      ]
+    }
+
+    TypeCoercionClient.ExtractPerson.call(args, %{
+      client_registry: client_registry,
+      parse: false
+    })
+  end
+
+  @tag :type_coercion
+  test "atom values are coerced to strings" do
+    assert {:ok, _} = call_extract_person(%{info: :hello})
+  end
+
+  @tag :type_coercion
+  test "Date values are coerced to ISO 8601 strings" do
+    assert {:ok, _} = call_extract_person(%{info: ~D[2024-01-15]})
+  end
+
+  @tag :type_coercion
+  test "DateTime values are coerced to ISO 8601 strings" do
+    assert {:ok, _} = call_extract_person(%{info: ~U[2024-01-15 10:30:00Z]})
+  end
+
+  @tag :type_coercion
+  test "existing types (strings, numbers, maps, lists) still work" do
+    assert {:ok, _} = call_extract_person(%{info: "hello"})
+  end
+
+  @tag :type_coercion
+  test "tuple values are coerced to lists (not unsupported type error)" do
+    # Tuples become lists; BAML will reject a list for a string param,
+    # but the important thing is no "Unsupported type" NIF error.
+    # Don't use the fake server since BAML rejects params before making HTTP call.
+    {:error, msg} =
+      BamlElixir.Client.call("ExtractPerson", %{info: {"hello", "world"}}, %{
+        path: "test/baml_src",
+        parse: false
+      })
+
+    refute msg =~ "Unsupported type"
+    assert msg =~ "Invalid parameters"
+  end
+
+  @tag :type_coercion
+  test "true, false, nil are not converted to strings" do
+    # Booleans and nil should pass through to the NIF as-is.
+    # BAML will reject them for a string param.
+    # Don't use the fake server since BAML rejects params before making HTTP call.
+    {:error, msg} =
+      BamlElixir.Client.call("ExtractPerson", %{info: true}, %{
+        path: "test/baml_src",
+        parse: false
+      })
+
+    refute msg =~ "Unsupported type"
+    assert msg =~ "Invalid parameters"
+  end
+end


### PR DESCRIPTION
## Summary
- Add `inject_code` option to `use BamlElixir.Client` for injecting custom functions into all generated BAML class modules
- Introduce `BamlElixir.Encoder` protocol for custom type serialization (Date, Time, DateTime, NaiveDateTime)
- Extend `to_map/1` to handle tuples and atom coercion for richer type support

## Test plan
- [x] `CustomCodeInjectionTest` verifies injected functions are callable on generated modules and `__MODULE__` resolves correctly
- [x] `TypeCoercionTest` verifies type coercion through the Encoder protocol
- [ ] Run full test suite: `mix test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)